### PR TITLE
Improve finding dependencies GMP, TinyXML and Argp

### DIFF
--- a/cmake/FindArgp.cmake
+++ b/cmake/FindArgp.cmake
@@ -1,0 +1,13 @@
+# Find ARGP libraries and include path
+
+# Locate libraries and headers for ARGP.
+find_path(ARGP_INCLUDE_DIR NAMES argp.h)
+find_library(ARGP_LIB NAMES argp)
+
+mark_as_advanced(ARGP_INCLUDE_DIR ARGP_LIB)
+
+# Determine if the package was found
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ARGP
+  DEFAULT_MSG
+  ARGP_LIB ARGP_INCLUDE_DIR)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,19 +1,15 @@
-# Try to find the GMP librairies
-# GMP_FOUND - system has GMP lib
-# GMP_INCLUDE_DIR - the GMP include directory
-# GMP_LIBRARIES - Libraries needed to use GMP
+# Find GMP libraries and include path
 
-if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
-    # Already in cache, be silent
-    set(GMP_FIND_QUIETLY TRUE)
-endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+# Locate libraries and headers for GMP.
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+find_path(GMPXX_INCLUDE_DIR NAMES gmpxx.h)
+find_library(GMP_LIB NAMES gmp libgmp)
+find_library(GMPXX_LIB NAMES gmpxx libgmpxx)
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h )
-find_library(GMP_LIBRARIES NAMES gmp libgmp )
-find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
-MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIB GMPXX_INCLUDE_DIR GMPXX_LIB)
 
+# Determine if the package was found
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
-
-mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)
+find_package_handle_standard_args(GMP
+  DEFAULT_MSG
+  GMP_LIB GMP_INCLUDE_DIR GMPXX_LIB GMPXX_INCLUDE_DIR)

--- a/cmake/FindTinyXML.cmake
+++ b/cmake/FindTinyXML.cmake
@@ -1,0 +1,13 @@
+# Find TINYXML libraries and include path
+
+# Locate libraries and headers for TinyXML.
+find_path(TINYXML_INCLUDE_DIR NAMES tinyxml.h)
+find_library(TINYXML_LIB NAMES tinyxml)
+
+mark_as_advanced(TINYXML_INCLUDE_DIR TINYXML_LIB)
+
+# Determine if the package was found
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TINYXML
+  DEFAULT_MSG
+  TINYXML_LIB TINYXML_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,16 @@ if(HAVE_PROFILER)
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # Check for ARGP
+    include(FindARGP)
+    if(ARGP_FOUND)
+        message(STATUS "ARGP Libraries: " ${ARGP_LIB} " with include path " ${ARGP_INCLUDE_DIR})
+        include_directories(${ARGP_INCLUDE_DIR})
+    else()
+        message(FATAL_ERROR "Cannot find ARGP library")
+    endif()
+
     # add argp library for OSX
-    target_link_libraries(sigrefmc argp)
-    target_link_libraries(sigrefmc_ht argp)
+    target_link_libraries(sigrefmc ${ARGP_LIB})
+    target_link_libraries(sigrefmc_ht ${ARGP_LIB})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,24 @@
 cmake_minimum_required(VERSION 2.6)
 project(sigref C CXX)
 
+# Check for GMP
+include(FindGMP)
+if(GMP_FOUND)
+  message(STATUS "GMP Libraries: " ${GMP_LIB} " " ${GMPXX_LIB} " with include path " ${GMP_INCLUDE_DIR} " " ${GMPXX_INCLUDE_DIR})
+  include_directories(${GMP_INCLUDE_DIR})
+else()
+  message(FATAL_ERROR "Cannot find GMP library")
+endif()
+
+# Check for TinyXML
+include(FindTinyXML)
+if(TINYXML_FOUND)
+  message(STATUS "TinyXML Libraries: " ${TINYXML_LIB} " with include path " ${TINYXML_INCLUDE_DIR})
+  include_directories(${TINYXML_INCLUDE_DIR})
+else()
+  message(FATAL_ERROR "Cannot find TinyXML library")
+endif()
+
 include_directories(.)
 
 set(SOURCES
@@ -32,21 +50,16 @@ set(SOURCES
     )
 
 add_executable(sigrefmc ${SOURCES} refine_sl.c)
-target_link_libraries(sigrefmc sylvan tinyxml gmp)
+target_link_libraries(sigrefmc sylvan ${TINYXML_LIB} ${GMP_LIB})
 
 add_executable(sigrefmc_ht ${SOURCES} refine_ht.c)
-target_link_libraries(sigrefmc_ht sylvan tinyxml gmp)
+target_link_libraries(sigrefmc_ht sylvan ${TINYXML_LIB} ${GMP_LIB})
 
 include(CheckIncludeFiles)
 check_include_files("gperftools/profiler.h" HAVE_PROFILER)
 
-find_path(HAVE_TINYXML_H tinyxml.h)
-
 find_package(Boost REQUIRED)
 
-if(NOT HAVE_TINYXML_H)
-    message(FATAL_ERROR "tinyxml not found")
-endif()
 
 if(HAVE_PROFILER)
     set_target_properties(sigrefmc PROPERTIES COMPILE_DEFINITIONS "HAVE_PROFILER")

--- a/sylvan/src/CMakeLists.txt
+++ b/sylvan/src/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(sylvan
     tls.h
 )
 
-target_link_libraries(sylvan m pthread)
+include_directories(${GMP_INCLUDE_DIR})
+target_link_libraries(sylvan m pthread ${GMP_LIB})
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(sylvan rt)
@@ -62,7 +63,7 @@ install(TARGETS
     sylvan
     DESTINATION "lib")
 
-install(FILES 
+install(FILES
     lace.h
     llmsset.h
     sylvan.h


### PR DESCRIPTION
On my Mac, building failed because the dependencies were not properly found. (Note that dependencies tinyxml, gmp and argp were installed using homebrew).

In this pull request, I updated FindGMP, and added FindTinyXML and FindArgp that can be used to search for each of the respective libraries. The variables that are set are subsequently used both in the CMakeLists for SigRefMC, as well as the included version of Sylvan.

For me, this fixes the MacOS build.